### PR TITLE
Audio Track Selection

### DIFF
--- a/src/VLCInput.cpp
+++ b/src/VLCInput.cpp
@@ -1,5 +1,6 @@
 /* ------------------------------------------------------------------
  * Copyright (C) 2022 Matthias P. Braendli
+ * Copyright (c) 2023 Andy Mace (andy.mace@mediauk.net)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -164,6 +165,11 @@ void VLCInput::prepare()
     // VLC options
     vector<string> vlc_args;
     vlc_args.push_back("--verbose=" + to_string(m_verbosity));
+
+    //Prevent TS with Multiple Audio Streams breaking the buffer. Select the 1st Audio Stream.
+    vlc_args.push_back("--no-video");
+    vlc_args.push_back("--no-sout-all");
+
 
     if (not m_cache.empty()) {
         vlc_args.push_back("--network-caching=" + m_cache);

--- a/src/VLCInput.cpp
+++ b/src/VLCInput.cpp
@@ -166,10 +166,15 @@ void VLCInput::prepare()
     vector<string> vlc_args;
     vlc_args.push_back("--verbose=" + to_string(m_verbosity));
 
-    //Prevent TS with Multiple Audio Streams breaking the buffer. Select the 1st Audio Stream.
+    //Prevent TS with Multiple Audio Streams breaking the buffer.
     vlc_args.push_back("--no-video");
     vlc_args.push_back("--no-sout-all");
 
+    std::stringstream cli_options_ss;
+    cli_options_ss << "--audio-track=" << m_audiotrack;
+    string cli_options = cli_options_ss.str();
+
+    vlc_args.push_back(cli_options);
 
     if (not m_cache.empty()) {
         vlc_args.push_back("--network-caching=" + m_cache);

--- a/src/VLCInput.h
+++ b/src/VLCInput.h
@@ -1,5 +1,6 @@
 /* ------------------------------------------------------------------
  * Copyright (C) 2022 Matthias P. Braendli
+ * Copyright (C) 2023 Andy Mace (andy.mace@mediauk.net)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +57,8 @@ class VLCInput : public InputInterface
                  unsigned verbosity,
                  std::string& cache,
                  std::vector<std::string>& additional_opts,
-                 SampleQueue<uint8_t>& queue) :
+                 SampleQueue<uint8_t>& queue,
+                 int audiotrack) :
             m_uri(uri),
             m_verbosity(verbosity),
             m_channels(channels),
@@ -67,7 +69,8 @@ class VLCInput : public InputInterface
             m_mp(nullptr),
             m_fault(false),
             m_running(false),
-            m_samplequeue(queue) {}
+            m_samplequeue(queue),
+            m_audiotrack(audiotrack) {}
 
         VLCInput(const VLCInput& other) = delete;
         VLCInput& operator=(const VLCInput& other) = delete;
@@ -157,6 +160,8 @@ class VLCInput : public InputInterface
         std::thread m_thread;
 
         SampleQueue<uint8_t>& m_samplequeue;
+        int m_audiotrack;
+
 };
 
 #endif // HAVE_VLC

--- a/src/odr-audioenc.cpp
+++ b/src/odr-audioenc.cpp
@@ -157,7 +157,7 @@ static void usage(const char* name)
     "                                          multiple times)\n"
     "     -L OPTION                            Give an additional options to VLC (can be given\n"
     "                                          multiple times)\n"
-    "     -T --audiotrack=track                Select specific audio track when multiple present, defaults to 1st"
+    "     -t --audiotrack=track                Select specific audio track when multiple present, defaults to 1st"
 #else
     "     The VLC input was disabled at compile-time\n"
 #endif


### PR DESCRIPTION
Made it easier to select the audio track where multiple audios are present.

on CLI.
-t 0 will select 1st audio
-t 1 - 2nd e.t.c

It defaults (opt not present) to -1 which is 1st available audio track.

Won't be offended if you don't merge!

A