### PR TITLE
Fix `example_stats_receiver.py`

### DIFF
--- a/example_stats_receiver.py
+++ b/example_stats_receiver.py
@@ -34,5 +34,5 @@ while True:
     data, addr = sock.recvfrom(256)
 
     logging.info("RX from {}". format(addr))
-    data = yaml.load(data)
+    data = yaml.safe_load(data)
     print(data)


### PR DESCRIPTION
This example script didn't work because the PyYAML library now requires specifying a Loader when calling yaml.load(). Using yaml.safe_load() fixes the script.